### PR TITLE
Fix root level RequestedForAt

### DIFF
--- a/requested_fields.go
+++ b/requested_fields.go
@@ -26,7 +26,11 @@ func RequestedForAt(ctx context.Context, resolver interface{}, pathToAppend stri
 	pathTree := strings.Join(path, ".")
 
 	if pathToAppend != "" {
-		pathTree += "." + pathToAppend
+		if pathTree == "" {
+			pathTree = pathToAppend
+		} else {
+			pathTree += "." + pathToAppend
+		}
 	}
 
 	return tree[pathTree]


### PR DESCRIPTION
Ran into an issue with running `.RequestedForAt` on QueryResolver, where `pathTree` would start with a dot and inevitably fail to look up the nodes. This fixes it.